### PR TITLE
Fix excessive database re-initialization, causing hangs

### DIFF
--- a/runparser/__init__.py
+++ b/runparser/__init__.py
@@ -8,7 +8,7 @@ import logging
 # set up logging
 filename = 'runparser.log'
 encoding = 'utf-8'
-output_fmt = '%(asctime)s: %(levelname)s: %(message)s'
+output_fmt = '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
 if os.getenv('CI') == 'true':
     level = logging.WARNING
 else:
@@ -28,7 +28,7 @@ from .runparser import RunParser
 from .autorunparser import AutoRunParser
 
 # db classes
-from .db import RunParserDB
+from .db import RunParserDB, RunParserDBConn
 
 # models
 from .models.runreport import RunReport

--- a/runparser/db/__init__.py
+++ b/runparser/db/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa: E401
 
-from .db import RunParserDB
+from .db import RunParserDB, RunParserDBConn

--- a/runparser/db/db.py
+++ b/runparser/db/db.py
@@ -14,106 +14,117 @@ from tinydb import TinyDB, Query
 
 import os
 import re
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class RunParserDB():
-    def __init__(self):
-        self.path = os.path.join(os.path.dirname(__file__), "db.json")
-        self.db = TinyDB(self.path, sort_keys=True, indent=4, separators=(',', ': '))
 
-    def __del__(self):
-        self.db.close()
+    class Controller():
+        def __init__(self):
+            self.path = os.path.join(os.path.dirname(__file__), "db.json")
+            self.db = TinyDB(self.path, sort_keys=True, indent=4, separators=(',', ': '))
 
-    def get_item(self, internal_name: str = None, name: str = None):
-        table = self.db.table('items')
-        Item = Query()
+        def __del__(self):
+            self.db.close()
 
-        # if internal_name is passed in
-        if internal_name is not None:
-            res = table.search(Item.internal_name.matches(internal_name, flags=re.IGNORECASE))
-            if len(res) == 0:
-                raise self.RPDB_EntryNotFoundError(f"Item with internal_name '{internal_name}' does not exist in database.")
+        def get_item(self, internal_name: str = None, name: str = None):
+            table = self.db.table('items')
+            Item = Query()
 
-        # else, if name is passed in
-        elif name is not None:
-            res = table.search(Item.name.matches(name, flags=re.IGNORECASE))
-            if len(res) == 0:
-                raise self.RPDB_EntryNotFoundError(f"Item with name '{name}' does not exist in database.")
+            # if internal_name is passed in
+            if internal_name is not None:
+                res = table.search(Item.internal_name.matches(internal_name, flags=re.IGNORECASE))
+                if len(res) == 0:
+                    raise self.EntryNotFoundError(f"Item with internal_name '{internal_name}' does not exist in database.")
 
-        # else, throw error
-        else:
-            raise self.RPDB_ArgumentError("Either 'internal_name' or 'name' must be passed in.")
+            # else, if name is passed in
+            elif name is not None:
+                res = table.search(Item.name.matches(name, flags=re.IGNORECASE))
+                if len(res) == 0:
+                    raise self.EntryNotFoundError(f"Item with name '{name}' does not exist in database.")
 
-        return res[0]
+            # else, throw error
+            else:
+                raise self.ArgumentError("Either 'internal_name' or 'name' must be passed in.")
 
-    def get_equipment(self, internal_name: str = None, name: str = None):
-        table = self.db.table('equipment')
-        Equipment = Query()
+            return res[0]
 
-        # if internal_name is passed in
-        if internal_name is not None:
-            res = table.search(Equipment.internal_name.matches(internal_name, flags=re.IGNORECASE))
-            if len(res) == 0:
-                raise self.RPDB_EntryNotFoundError(f"Equipment with internal_name '{internal_name}' does not exist in database.")
+        def get_equipment(self, internal_name: str = None, name: str = None):
+            table = self.db.table('equipment')
+            Equipment = Query()
 
-        # else, if name is passed in
-        elif name is not None:
-            res = table.search(Equipment.name.matches(name, flags=re.IGNORECASE))
-            if len(res) == 0:
-                raise self.RPDB_EntryNotFoundError(f"Equipment with name '{name}' does not exist in database.")
+            # if internal_name is passed in
+            if internal_name is not None:
+                res = table.search(Equipment.internal_name.matches(internal_name, flags=re.IGNORECASE))
+                if len(res) == 0:
+                    raise self.EntryNotFoundError(f"Equipment with internal_name '{internal_name}' does not exist in database.")
 
-        # else, throw error
-        else:
-            raise self.RPDB_ArgumentError("Either 'internal_name' or 'name' must be passed in.")
+            # else, if name is passed in
+            elif name is not None:
+                res = table.search(Equipment.name.matches(name, flags=re.IGNORECASE))
+                if len(res) == 0:
+                    raise self.EntryNotFoundError(f"Equipment with name '{name}' does not exist in database.")
 
-        return res[0]
+            # else, throw error
+            else:
+                raise self.ArgumentError("Either 'internal_name' or 'name' must be passed in.")
 
-    def get_artifact(self, internal_name: str = None, name: str = None):
-        table = self.db.table('artifacts')
-        Artifact = Query()
+            return res[0]
 
-        # if internal_name is passed in
-        if internal_name is not None:
-            res = table.search(Artifact.internal_name.matches(internal_name, flags=re.IGNORECASE))
-            if len(res) == 0:
-                raise self.RPDB_EntryNotFoundError(f"Artifact with internal_name '{internal_name}' does not exist in database.")
+        def get_artifact(self, internal_name: str = None, name: str = None):
+            table = self.db.table('artifacts')
+            Artifact = Query()
 
-        # else, if name is passed in
-        elif name is not None:
-            res = table.search(Artifact.name.matches(name, flags=re.IGNORECASE))
-            if len(res) == 0:
-                raise self.RPDB_EntryNotFoundError(f"Artifact with name '{name}' does not exist in database.")
+            # if internal_name is passed in
+            if internal_name is not None:
+                res = table.search(Artifact.internal_name.matches(internal_name, flags=re.IGNORECASE))
+                if len(res) == 0:
+                    raise self.EntryNotFoundError(f"Artifact with internal_name '{internal_name}' does not exist in database.")
 
-        # else, throw error
-        else:
-            raise self.RPDB_ArgumentError("Either 'internal_name' or 'name' must be passed in.")
+            # else, if name is passed in
+            elif name is not None:
+                res = table.search(Artifact.name.matches(name, flags=re.IGNORECASE))
+                if len(res) == 0:
+                    raise self.EntryNotFoundError(f"Artifact with name '{name}' does not exist in database.")
 
-        return res[0]
+            # else, throw error
+            else:
+                raise self.ArgumentError("Either 'internal_name' or 'name' must be passed in.")
 
-    def get_survivor(self, internal_name: str = None, name: str = None):
-        table = self.db.table('survivors')
-        Survivor = Query()
+            return res[0]
 
-        # if internal_name is passed in
-        if internal_name is not None:
-            res = table.search(Survivor.internal_name.matches(internal_name, flags=re.IGNORECASE))
-            if len(res) == 0:
-                raise self.RPDB_EntryNotFoundError(f"Survivor with internal_name '{internal_name}' does not exist in database.")
+        def get_survivor(self, internal_name: str = None, name: str = None):
+            table = self.db.table('survivors')
+            Survivor = Query()
 
-        # else, if name is passed in
-        elif name is not None:
-            res = table.search(Survivor.name.matches(name, flags=re.IGNORECASE))
-            if len(res) == 0:
-                raise self.RPDB_EntryNotFoundError(f"Survivor with name '{name}' does not exist in database.")
+            # if internal_name is passed in
+            if internal_name is not None:
+                res = table.search(Survivor.internal_name.matches(internal_name, flags=re.IGNORECASE))
+                if len(res) == 0:
+                    raise self.EntryNotFoundError(f"Survivor with internal_name '{internal_name}' does not exist in database.")
 
-        # else, throw error
-        else:
-            raise self.RPDB_ArgumentError("Either 'internal_name' or 'name' must be passed in.")
+            # else, if name is passed in
+            elif name is not None:
+                res = table.search(Survivor.name.matches(name, flags=re.IGNORECASE))
+                if len(res) == 0:
+                    raise self.EntryNotFoundError(f"Survivor with name '{name}' does not exist in database.")
 
-        return res[0]
+            # else, throw error
+            else:
+                raise self.ArgumentError("Either 'internal_name' or 'name' must be passed in.")
 
-    class RPDB_EntryNotFoundError(Exception):
-        pass
+            return res[0]
 
-    class RPDB_ArgumentError(Exception):
-        pass
+        class EntryNotFoundError(Exception):
+            pass
+
+        class ArgumentError(Exception):
+            pass
+
+    _conn: Controller = Controller()
+
+
+def RunParserDBConn():
+    return RunParserDB._conn

--- a/runparser/models/artifact.py
+++ b/runparser/models/artifact.py
@@ -12,7 +12,7 @@ This module implements the class that represents each Artifact.
 
 import logging
 
-from ..db import RunParserDB
+from ..db import RunParserDBConn
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class Artifact():
     def __init__(self, internal_name: str = None):
         self._reset()
         if internal_name is not None:
-            db = RunParserDB()
+            db = RunParserDBConn()
             artifact_data = db.get_artifact(internal_name=internal_name)
             self._parse(artifact_data)
 

--- a/runparser/models/equipment.py
+++ b/runparser/models/equipment.py
@@ -13,7 +13,7 @@ This module implements the class that represents each Equipment.
 import logging
 
 from ..utils.enums import EquipmentRarityEnum
-from ..db import RunParserDB
+from ..db import RunParserDBConn
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class Equipment():
     def __init__(self, internal_name: str = None):
         self._reset()
         if internal_name is not None:
-            db = RunParserDB()
+            db = RunParserDBConn()
             item_data = db.get_equipment(internal_name=internal_name)
             self._parse(item_data)
 

--- a/runparser/models/item.py
+++ b/runparser/models/item.py
@@ -13,7 +13,7 @@ This module implements the class that represents each Item.
 import logging
 
 from ..utils.enums import ItemRarityEnum
-from ..db import RunParserDB
+from ..db import RunParserDBConn
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class Item():
     def __init__(self, internal_name: str = None, count: int = None):
         self._reset()
         if internal_name is not None:
-            db = RunParserDB()
+            db = RunParserDBConn()
             item_data = db.get_item(internal_name=internal_name)
             self._parse(item_data)
         self.count = count

--- a/runparser/models/survivor.py
+++ b/runparser/models/survivor.py
@@ -12,7 +12,7 @@ This module implements the class that represents each Survivor.
 
 import logging
 
-from ..db import RunParserDB
+from ..db import RunParserDBConn
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class Survivor():
     def __init__(self, internal_name: str = None):
         self._reset()
         if internal_name is not None:
-            db = RunParserDB()
+            db = RunParserDBConn()
             survivor_data = db.get_survivor(internal_name=internal_name)
             self._parse(survivor_data)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from runparser import RunParserDB
+from runparser.db import RunParserDB, RunParserDBConn
 
 import unittest
 
@@ -8,15 +8,9 @@ import unittest
 class test_RunParserDB(unittest.TestCase):
     """Basic RunParserDB test cases."""
 
-    db: RunParserDB = None
-
     def setUp(self):
         """Set up the test cases."""
-        self.db = RunParserDB()
-
-    def tearDown(self):
-        """Tear down the test cases."""
-        del self.db
+        self.db = RunParserDBConn()
 
     def test_RunParserDB_Items(self):
         """Test getting Item data."""
@@ -30,15 +24,15 @@ class test_RunParserDB(unittest.TestCase):
         self.assertEqual(item['internal_name'], "EquipmentMagazine")
 
         # get nonexistent item by internal name
-        with self.assertRaises(RunParserDB.RPDB_EntryNotFoundError):
+        with self.assertRaises(RunParserDB.Controller.EntryNotFoundError):
             self.db.get_item("thisdoesnotexist")
 
         # get nonexistent item by actual name
-        with self.assertRaises(RunParserDB.RPDB_EntryNotFoundError):
+        with self.assertRaises(RunParserDB.Controller.EntryNotFoundError):
             self.db.get_item(name="Fake Item")
 
         # call with no arguments
-        with self.assertRaises(RunParserDB.RPDB_ArgumentError):
+        with self.assertRaises(RunParserDB.Controller.ArgumentError):
             self.db.get_item()
 
     def test_RunParserDB_Equipment(self):
@@ -53,15 +47,15 @@ class test_RunParserDB(unittest.TestCase):
         self.assertEqual(item['internal_name'], "Meteor")
 
         # get nonexistent equipment by internal name
-        with self.assertRaises(RunParserDB.RPDB_EntryNotFoundError):
+        with self.assertRaises(RunParserDB.Controller.EntryNotFoundError):
             self.db.get_equipment("thisdoesnotexist")
 
         # get nonexistent equipment by actual name
-        with self.assertRaises(RunParserDB.RPDB_EntryNotFoundError):
+        with self.assertRaises(RunParserDB.Controller.EntryNotFoundError):
             self.db.get_equipment(name="Fake Equipment")
 
         # call with no arguments
-        with self.assertRaises(RunParserDB.RPDB_ArgumentError):
+        with self.assertRaises(RunParserDB.Controller.ArgumentError):
             self.db.get_equipment()
 
     def test_RunParserDB_Artifacts(self):
@@ -76,15 +70,15 @@ class test_RunParserDB(unittest.TestCase):
         self.assertEqual(item['internal_name'], "Sacrifice")
 
         # get artifact equipment by internal name
-        with self.assertRaises(RunParserDB.RPDB_EntryNotFoundError):
+        with self.assertRaises(RunParserDB.Controller.EntryNotFoundError):
             self.db.get_artifact("thisdoesnotexist")
 
         # get artifact equipment by actual name
-        with self.assertRaises(RunParserDB.RPDB_EntryNotFoundError):
+        with self.assertRaises(RunParserDB.Controller.EntryNotFoundError):
             self.db.get_artifact(name="Fake Artifact")
 
         # call with no arguments
-        with self.assertRaises(RunParserDB.RPDB_ArgumentError):
+        with self.assertRaises(RunParserDB.Controller.ArgumentError):
             self.db.get_artifact()
 
     def test_RunParserDB_Survivors(self):
@@ -99,13 +93,13 @@ class test_RunParserDB(unittest.TestCase):
         self.assertEqual(item['internal_name'], "Toolbot")
 
         # get survivor equipment by internal name
-        with self.assertRaises(RunParserDB.RPDB_EntryNotFoundError):
+        with self.assertRaises(RunParserDB.Controller.EntryNotFoundError):
             self.db.get_survivor("thisdoesnotexist")
 
         # get survivor equipment by actual name
-        with self.assertRaises(RunParserDB.RPDB_EntryNotFoundError):
+        with self.assertRaises(RunParserDB.Controller.EntryNotFoundError):
             self.db.get_survivor(name="Fake Survivor")
 
         # call with no arguments
-        with self.assertRaises(RunParserDB.RPDB_ArgumentError):
+        with self.assertRaises(RunParserDB.Controller.ArgumentError):
             self.db.get_survivor()


### PR DESCRIPTION
This fixes the issue referenced in #6.

The version of RunReport introduced in #4 took a long time when parsing large amounts of data, specifically while parsing data recursively using the new models also introduced in that PR. 

The process of parsing the average run using RunReport initializes 16 Artifact, 102 Item, and 24 Equipment objects, each of which originally initialized their own internal copy of the database. Each run also initializes anywhere from one to four Player objects, which initializes EVEN MORE Item and Equipment objects. This repetitive initialization/destruction of many RunParserDB objects seemed to be the culprit here.

This pull request fixes the issue by reworking RunParserDB to hold a single static instance of the database connection, called _conn. It also introduces RunParserDBConn, a global function which returns the connection from RunParserDB._conn.

It looks to improve speeds by over 200%. :)